### PR TITLE
動物回転画面から動物一覧画面に遷移した際に回転を止める

### DIFF
--- a/StupidSpinAll/ContentView.swift
+++ b/StupidSpinAll/ContentView.swift
@@ -9,11 +9,14 @@ import SwiftUI
 
 struct ContentView: View {
     let imageList = ["dog", "fukurou", "ika", "kirin", "shika", "shirokuma", "zarigani"]
+    let spinTimer = SpinTimer(timer: Timer(), angle: 0.0)
     
     var body: some View {
         NavigationView {
             List(0 ..< imageList.count) { index in
-                NavigationLink(destination: AnimalSpin(imageName: imageList[index])) {
+                NavigationLink(destination: AnimalSpin(timer: spinTimer, imageName: imageList[index]).onDisappear() {
+                    spinTimer.stop()
+                }) {
                     AnimalRow(imageName: imageList[index])
                 }
             }

--- a/StupidSpinAll/Views/AnimalSpin.swift
+++ b/StupidSpinAll/Views/AnimalSpin.swift
@@ -8,7 +8,7 @@
 import SwiftUI
 
 struct AnimalSpin: View {
-    @ObservedObject var timer = SpinTimer(timer: Timer(), angle: 0.0)
+    @ObservedObject var timer: SpinTimer
     let imageName: String
     
     var body: some View {
@@ -33,6 +33,6 @@ struct AnimalSpin: View {
 
 struct AnimalSpin_Previews: PreviewProvider {
     static var previews: some View {
-        AnimalSpin(imageName: "dog")
+        AnimalSpin(timer: SpinTimer(timer: Timer(), angle: 0.0), imageName: "dog")
     }
 }


### PR DESCRIPTION
# 概要
動物回転画面で動物を回転させたまま一覧画面にも戻った際に、回転をStopさせるようにした。

ユーザーが見ていない所で動物を回す意味はなかった。
さらに動物ごとにangleを変更するTimerを持っていたので、回転させたままだとメモリ使いすぎのリスクがあった。

# 内容
- AnimalSpin画面でTimerを親から受け取るように変更
- AnimalSpin画面のpreviewでTimerを渡すよう変更
- ContentViewで全動物共通のSpinTimerを作成
- onDisappearを追加し、SpinTimerをstopする処理を追加